### PR TITLE
ci(semgrep): declare contents: read on the daily scan

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 name: Semgrep config
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: semgrep/ci


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` to `semgrep.yml`, the sole workflow here. The scan runs in the official `returntocorp/semgrep` container, reads the checkout, and reports findings to Cloudflare's own Semgrep AppSec instance via `SEMGREP_APP_TOKEN` — none of that requires write scopes on the GitHub token.

Verified with `yaml.safe_load`.